### PR TITLE
Use existing `QApplication`

### DIFF
--- a/lyse/__main__.py
+++ b/lyse/__main__.py
@@ -2327,7 +2327,9 @@ if __name__ == "__main__":
     logger = setup_logging('lyse')
     labscript_utils.excepthook.set_logger(logger)
     logger.info('\n\n===============starting===============\n')
-    qapplication = QtWidgets.QApplication(sys.argv)
+    qapplication = QtWidgets.QApplication.instance()
+    if qapplication is None:
+        qapplication = QtWidgets.QApplication(sys.argv)
     qapplication.setAttribute(QtCore.Qt.AA_DontShowIconsInMenus, False)
     app = Lyse()
 

--- a/lyse/analysis_subprocess.py
+++ b/lyse/analysis_subprocess.py
@@ -531,7 +531,9 @@ if __name__ == '__main__':
     # Set a meaningful client id for zlock
     process_tree.zlock_client.set_process_name('lyse-'+os.path.basename(filepath))
 
-    qapplication = QtWidgets.QApplication(sys.argv)
+    qapplication = QtWidgets.QApplication.instance()
+    if qapplication is None:
+        qapplication = QtWidgets.QApplication(sys.argv)
     worker = AnalysisWorker(filepath, to_parent, from_parent)
     qapplication.exec_()
         


### PR DESCRIPTION
Instead of creating a new one unconditionally. The splash screen already
creates a `QApplication`, so we had two existing in the interpreter.
Having multiple `QApplication`s in the same thread (possibly in the same
process?) is not allowed and leads to segfaults on `PyQt5` and Python
exceptions on `PySide2`.

Initially reported in labscript-suite/runmanager#74