### PR TITLE
Use `desktop-app` package for desktop integration

### DIFF
--- a/lyse/desktop-app.json
+++ b/lyse/desktop-app.json
@@ -1,0 +1,4 @@
+{
+    "product_name": "Labscript Suite",
+    "modules": {"lyse": {"display_name": "lyse - the labscript suite"}}
+}

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ INSTALL_REQUIRES = [
     "matplotlib",
     "scipy",
     "tzlocal",
+    "desktop-app"
 ]
 
 setup(
@@ -70,6 +71,10 @@ setup(
     url='http://labscriptsuite.org',
     license="BSD",
     packages=["lyse"],
+    entry_points={
+        'console_scripts': ['lyse = desktop_app:entry_point'],
+        'gui_scripts': ["lyse-gui = desktop_app:entry_point"],
+    },
     zip_safe=False,
     setup_requires=['setuptools', 'setuptools_scm'],
     include_package_data=True,


### PR DESCRIPTION
Instead of `labscript_utils.winshell` and `labscript_utils.winlauncher`.

OS menu (e.g. Start menu on Windows) shortcuts can be created with
`desktop-app install lyse`

And lyse can be run from the terminal with `lyse` or
`lyse-gui` to run without a console on Windows.