### PR TITLE
Declarative setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = runmanager
+name = lyse
 description = Automated analysis queue for labscript suite experiments
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,54 @@
+[metadata]
+name = runmanager
+description = Automated analysis queue for labscript suite experiments
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = The labscript suite community
+author_email = labscriptsuite@googlegroups.com
+url = http://labscriptsuite.org
+project_urls = 
+    Source Code=https://github.com/labscript-suite/lyse
+    Download=https://github.com/labscript-suite/lyse/releases
+    Tracker=https://github.com/labscript-suite/lyse/issues
+keywords = experiment analysis automation
+license = BSD
+classifiers =
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+zip_safe = False
+include_package_data = True
+packages = find:
+python_requires = >=3.6
+install_requires =
+  desktop-app>=0.1.2
+  h5py
+  labscript_utils>=2.14.0
+  matplotlib
+  numpy
+  pandas>=0.21
+  qtutils>=2.2.2
+  runmanager
+  scipy
+  tzlocal
+  zprocess>=2.2.2
+setup_requires =
+  setuptools_scm
+
+[options.entry_points]
+console_scripts =
+  lyse = desktop_app:entry_point
+gui_scripts = 
+  lyse-gui = desktop_app:entry_point
+
+[options.extras_require]
+pyqt = PyQt5
+
+[dist_conda]
+pythons = 3.6, 3.7, 3.8
+platforms = linux-64,win-32,win-64,osx-64
+force_conversion = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,5 +50,3 @@ pyqt = PyQt5
 
 [dist_conda]
 pythons = 3.6, 3.7, 3.8
-platforms = linux-64,win-32,win-64,osx-64
-force_conversion = True

--- a/setup.py
+++ b/setup.py
@@ -8,27 +8,12 @@ try:
 except ImportError:
     CMDCLASS = {}
 
-if "CONDA_BUILD" not in os.environ:
-    dist = Distribution()
-    dist.parse_config_files()
-    INSTALL_REQUIRES = dist.install_requires
-else:
-    INSTALL_REQUIRES = []
-
-VERSION_SCHEME = {}
-VERSION_SCHEME["version_scheme"] = os.environ.get(
-    "SCM_VERSION_SCHEME", "guess-next-dev"
-)
-VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
-
-VERSION_SCHEME = {}
-VERSION_SCHEME["version_scheme"] = os.environ.get(
-    "SCM_VERSION_SCHEME", "release-branch-semver"
-)
-VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
 
 setup(
     use_scm_version=VERSION_SCHEME,
     cmdclass=CMDCLASS,
-    install_requires=INSTALL_REQUIRES
 )

--- a/setup.py
+++ b/setup.py
@@ -1,91 +1,34 @@
-# USAGE NOTES
-#
-# Make a PyPI release tarball with:
-#
-#     python setup.py sdist
-#
-# Upload to test PyPI with:
-#
-#     twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-#
-# Install from test PyPI with:
-#
-#     pip install --index-url https://test.pypi.org/simple/ lyse
-#
-# Upload to real PyPI with:
-#
-#     twine upload dist/*
-#
-# Build conda packages for all platforms (in a conda environment with setuptools_conda
-# installed) with:
-#
-#     python setup.py dist_conda
-#
-# Upoad to your own account (for testing) on anaconda cloud (in a conda environment with
-# anaconda-client installed) with:
-#
-#     anaconda upload --skip-existing conda_packages/*/*
-#
-# (Trickier on Windows, as it won't expand the wildcards)
-#
-# Upoad to the labscript-suite organisation's channel on anaconda cloud (in a
-# conda environment with anaconda-client installed) with:
-#
-#     anaconda -c labscript-suite upload --skip-existing conda_packages/*/*
-#
-# If you need to rebuild the same version of the package for conda due to a packaging
-# issue, you must increment CONDA_BUILD_NUMBER in order to create a unique version on
-# anaconda cloud. When subsequently releasing a new version of the package,
-# CONDA_BUILD_NUMBER should be reset to zero.
-
 import os
 from setuptools import setup
+from setuptools.dist import Distribution
 
 try:
     from setuptools_conda import dist_conda
+    CMDCLASS = {"dist_conda": dist_conda}
 except ImportError:
-    dist_conda = None
+    CMDCLASS = {}
 
-INSTALL_REQUIRES = [
-    "labscript_utils >=2.14.0",
-    "runmanager",
-    "qtutils >=2.2.2",
-    "zprocess >=2.2.2",
-    "pandas >=0.21",
-    "h5py",
-    "numpy",
-    "matplotlib",
-    "scipy",
-    "tzlocal",
-    "desktop-app"
-]
+if "CONDA_BUILD" not in os.environ:
+    dist = Distribution()
+    dist.parse_config_files()
+    INSTALL_REQUIRES = dist.install_requires
+else:
+    INSTALL_REQUIRES = []
+
+VERSION_SCHEME = {}
+VERSION_SCHEME["version_scheme"] = os.environ.get(
+    "SCM_VERSION_SCHEME", "guess-next-dev"
+)
+VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
+
+VERSION_SCHEME = {}
+VERSION_SCHEME["version_scheme"] = os.environ.get(
+    "SCM_VERSION_SCHEME", "release-branch-semver"
+)
+VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
 
 setup(
-    name='lyse',
-    use_scm_version=True,
-    description="Program to set parameters and compile shots with labscript",
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    author='The labscript suite community',
-    author_email='labscriptsuite@googlegroups.com ',
-    url='http://labscriptsuite.org',
-    license="BSD",
-    packages=["lyse"],
-    entry_points={
-        'console_scripts': ['lyse = desktop_app:entry_point'],
-        'gui_scripts': ["lyse-gui = desktop_app:entry_point"],
-    },
-    zip_safe=False,
-    setup_requires=['setuptools', 'setuptools_scm'],
-    include_package_data=True,
-    python_requires=">=3.6",
-    install_requires=INSTALL_REQUIRES if 'CONDA_BUILD' not in os.environ else [],
-    cmdclass={'dist_conda': dist_conda} if dist_conda is not None else {},
-    command_options={
-        'dist_conda': {
-            'pythons': (__file__, ['3.6', '3.7', '3.8']),
-            'platforms': (__file__, ['linux-64', 'win-32', 'win-64', 'osx-64']),
-            'force_conversion': (__file__, True),
-        },
-    },
+    use_scm_version=VERSION_SCHEME,
+    cmdclass=CMDCLASS,
+    install_requires=INSTALL_REQUIRES
 )


### PR DESCRIPTION
This PR introduces setup.cfg and makes setup.py as simple as possible, containing only programmatic overrides.

1. This allows setup.py to be identical (or near-identical) for all packages in the labscript suite.
1. Only additions in setup.cfg to existing configuration are:
   - Explicit `version_scheme` and `local_scheme` for setuptools_scm, overridden by environment variables `SCM_VERSION_SCHEME` and `SCM_LOCAL_SCHEME`, respectively, in anticipation of automated release process. (Default `version_scheme` will be updated to [`release-branch-semver`](pypa/setuptools_scm#430) upon next release of setuptools_scm.)
   - Added keywords and classifiers to metadata.
   - Reworded description, which referred to runmanager (!).
   - Added 'Source Code', 'Download', and (issue) 'Tracker' URLs to metadata to adorn PyPI sidebar.
1. Regarding building conda distributions, see chrisjbillington/setuptools_conda#1.