### PR TITLE
Obtain own version without external functions

### DIFF
--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -27,11 +27,7 @@ import pandas
 from numpy import array, ndarray
 import types
 
-from labscript_utils.versions import get_version, NoVersionInfo
-from pathlib import Path
-__version__ = get_version(__name__, import_path=Path(__file__).parent.parent)
-if __version__ is NoVersionInfo:
-    __version__ = None
+from .__version__ import __version__
 
 try:
     from labscript_utils import check_version

--- a/lyse/__version__.py
+++ b/lyse/__version__.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
+
+root = Path(__file__).parent.parent
+if (root / '.git').is_dir():
+    from setuptools_scm import get_version
+    __version__ = get_version(root, **VERSION_SCHEME)
+else:
+    try:
+        __version__ = importlib_metadata.version(__package__)
+    except importlib_metadata.PackageNotFoundError:
+        __version__ = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.6
 install_requires =
   desktop-app>=0.1.2
   h5py
-  importlib_metadata ; python_version<'3.8'
+  importlib_metadata
   labscript_utils>=2.14.0
   matplotlib
   numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ python_requires = >=3.6
 install_requires =
   desktop-app>=0.1.2
   h5py
+  importlib_metadata ; python_version<'3.8'
   labscript_utils>=2.14.0
   matplotlib
   numpy


### PR DESCRIPTION
Per labscript-suite/runmanager#81, with the addition of making the importlib_metadata requirement python<'3.8'.