### PR TITLE
Make Run.set_group() create the group if necessary.

### DIFF
--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -147,7 +147,7 @@ class Run(object):
 
     def set_group(self, groupname):
         self.group = groupname
-        self._create_group_if_not_exists(self.h5_path, '/', 'results')
+        self._create_group_if_not_exists(self.h5_path, '/results', self.group)
         # restore no_write attribute now we have set the group
         if self._no_group is not None and self._no_group[0]:
             self.no_write = self._no_group[1]


### PR DESCRIPTION
Calling `Run.set_group()` used to create the group if it didn't already exist:

https://github.com/labscript-suite/lyse/blob/74dfc19a8b3bcfeddaff63d11f21ca847184a36b/lyse/__init__.py#L133-L137

However after https://github.com/labscript-suite/lyse/pull/71, `Run.set_group()` only makes the `'/results'` group:

https://github.com/labscript-suite/lyse/blob/f7a14277e45f57c34f71ccd7d85fb072c67ce412/lyse/__init__.py#L148-L150

This PR just changes the last line in that excerpt to `self._create_group_if_not_exists(self.h5_path, '/results', self.group)` to restore the previous behavior.