### PR TITLE
Bugfix for sequence

### DIFF
--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -246,6 +246,7 @@ class Run(object):
             if not group:
                 # Save dataset to results group by default
                 group = 'results/' + self.group
+                
             elif not group in h5_file:
                 # Create the group if it doesn't exist
                 h5_file.create_group(group) 
@@ -422,6 +423,11 @@ class Sequence(Run):
             run_paths = run_paths['filepath']
         self.h5_path = h5_path
         self.no_write = no_write
+        try:
+            h5py.File(h5_path, 'r')
+        except:
+            h5py.File(h5_path,'w')
+
         if not self.no_write:
             self._create_group_if_not_exists(h5_path, '/', 'results')
                  


### PR DESCRIPTION
When instantiating a sequence, usually a _result.h5-file was created to save sequence results. However, currently h5-files are only opened in read mode via h5py.File(filename, 'r') which is not creating new files if they do not exist. This is solved by first trying to open the cooresponding h5-file in read mode and is an exeption is thrown to open it in write mode. This is only added in the sequence instatiation as single shots have there shot-h5-file.