### PR TITLE
Add n_runs column to lyse dataframe

### DIFF
--- a/lyse/dataframe_utilities.py
+++ b/lyse/dataframe_utilities.py
@@ -66,6 +66,10 @@ def get_nested_dict_from_shot(filepath):
             row['run repeat'] = h5_file.attrs['run repeat']
         except KeyError:
             row['run repeat'] = 0
+        try:
+            row['n_runs'] = h5_file.attrs['n_runs']
+        except KeyError:
+            row['n_runs'] = float('nan')
         return row
             
 def flatten_dict(dictionary, keys=tuple()):


### PR DESCRIPTION
In my lab we often want to find out if all the shots from a click on "Engage" in runmanager have finished. To do this we need to compare the `n_runs` and `run number` attributes of the root directory of a shot's hdf5 file.

It would be convenient if both of those pieces of information were included in the lyse dataframe, and that could make it easier for new users to find that info as well. The lyse dataframe already has a `run number` column, so this PR simply adds an `n_runs` column to the lyse dataframe.