### PR TITLE
Fix 78

### DIFF
--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -116,9 +116,9 @@ class Run(object):
             to the file. Defaults to `False`.
     """
     def __init__(self,h5_path,no_write=False):
-        self.__h5_path = h5_path
-        self.__no_write = no_write
-        self.__group = None
+        self._h5_path = h5_path
+        self._no_write = no_write
+        self._group = None
         if not self.no_write:
             self._create_group_if_not_exists(h5_path, '/', 'results')
                      
@@ -142,12 +142,12 @@ class Run(object):
     @property
     def h5_path(self):
         """str: The value provided for `h5_path` during instantiation."""
-        return self.__h5_path
+        return self._h5_path
 
     @property
     def no_write(self):
         """bool: The value provided for `no_write` during instantiation."""
-        return self.__no_write
+        return self._no_write
 
     @property
     def group(self):
@@ -164,7 +164,7 @@ class Run(object):
             Attempting to directly set `self.group`'s value will automatically
             call `self.set_group()`.
         """
-        return self.__group
+        return self._group
 
     @group.setter
     def group(self, value):
@@ -206,7 +206,7 @@ class Run(object):
                 `'/results'` group of the hdf5 file.
         """
         self._create_group_if_not_exists(self.h5_path, '/results', groupname)
-        self.__group = groupname
+        self._group = groupname
 
     def trace_names(self):
         with h5py.File(self.h5_path, 'r') as h5_file:

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -317,7 +317,7 @@ class Run(object):
                         group=group,
                         name=name,
                     )
-                raise PermissionError(dedent(msg))                 
+                raise PermissionError(dedent(msg))
             set_attributes(h5_file[group], {name: value})
             
         if spinning_top:

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -286,20 +286,17 @@ class Run(object):
                 raised. Defaults to `True`.
 
         Raises:
-            Exception: An `Exception` is raised if `self.no_write` is `True`
-                because saving the result would edit the file.
+            PermissionError: A `PermissionError` is raised if `self.no_write` is
+                `True` because saving the result would edit the file.
             ValueError: A `ValueError` is raised if `self.group` is `None` and
                 no value is provided for `group` because the method then doesn't
                 know where to save the result.
-            Exception: An `Exception` is raised if an attribute with name `name`
-                already exists but `overwrite` is set to `False`.
+            PermissionError: A `PermissionError` is raised if an attribute with
+                name `name` already exists but `overwrite` is set to `False`.
         """
         if self.no_write:
-            raise Exception('This run is read-only. '
-                            'You can\'t save results to runs through a '
-                            'Sequence object. Per-run analysis should be done '
-                            'in single-shot analysis routines, in which a '
-                            'single Run object is used')
+            msg = "Cannot save result; this instance is read-only."
+            raise PermissionError(msg)
         with h5py.File(self.h5_path,'a') as h5_file:
             if not group:
                 if self.group is None:
@@ -314,8 +311,13 @@ class Run(object):
                 # Create the group if it doesn't exist
                 h5_file.create_group(group) 
             if name in h5_file[group].attrs and not overwrite:
-                raise Exception('Attribute %s exists in group %s. ' \
-                                'Use overwrite=True to overwrite.' % (name, group))                   
+                msg = """Cannot save result; group '{group}' already has
+                    attribute '{name}' and overwrite is set to False. Set
+                    overwrite=True to overwrite the existing value.""".format(
+                        group=group,
+                        name=name,
+                    )
+                raise PermissionError(dedent(msg))                 
             set_attributes(h5_file[group], {name: value})
             
         if spinning_top:

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -279,10 +279,10 @@ class Run(object):
                 results anywhere in the hdf5 file. This is in contrast to using
                 the default group set with `self.set_group()`; when the default
                 group is set with that method it WILL have `'/results'`
-                prepended to it when before saving results. Defaults to `None`.
+                prepended to it when saving results. Defaults to `None`.
             overwrite (bool, optional): Sets whether or not to overwrite the
                 previous value if the attribute already exists. If set to
-                `False` and the attribute already exists, an `Exception` is
+                `False` and the attribute already exists, a `PermissionError` is
                 raised. Defaults to `True`.
 
         Raises:

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -116,9 +116,9 @@ class Run(object):
             to the file. Defaults to `False`.
     """
     def __init__(self,h5_path,no_write=False):
-        self._h5_path = h5_path
-        self._no_write = no_write
-        self._group = None
+        self.__h5_path = h5_path
+        self.__no_write = no_write
+        self.__group = None
         if not self.no_write:
             self._create_group_if_not_exists(h5_path, '/', 'results')
                      
@@ -156,12 +156,12 @@ class Run(object):
     @property
     def h5_path(self):
         """str: The value provided for `h5_path` during instantiation."""
-        return self._h5_path
+        return self.__h5_path
 
     @property
     def no_write(self):
         """bool: The value provided for `no_write` during instantiation."""
-        return self._no_write
+        return self.__no_write
 
     @property
     def group(self):
@@ -178,7 +178,7 @@ class Run(object):
         Attempting to directly set `self.group`'s value will automatically call
         `self.set_group()`.
         """
-        return self._group
+        return self.__group
 
     @group.setter
     def group(self, value):
@@ -220,7 +220,7 @@ class Run(object):
                 `'/results'` group of the hdf5 file.
         """
         self._create_group_if_not_exists(self.h5_path, '/results', groupname)
-        self._group = groupname
+        self.__group = groupname
 
     def trace_names(self):
         with h5py.File(self.h5_path, 'r') as h5_file:

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -102,6 +102,31 @@ def globals_diff(run1, run2, group=None):
     return dict_diff(run1.get_globals(group), run2.get_globals(group))
  
 class Run(object):
+    """A class for saving/retrieving data to/from a run's hdf5 file.
+
+    This class implements methods that allow the user to retrieve data from a
+    run's hdf5 file such as images, traces, and the values of globals. It also
+    provides methods for saving and retrieving results from analysis.
+
+    Args:
+        h5_path (str): The path, including file name and extension, to the hdf5
+            file for a run.
+        no_write (bool, optional): Set to `True` to prevent editing the run
+            file. Note that doing so prohibits the ability to save results to
+            the file. Defaults to `False`.
+
+    Attributes:
+        h5_path (str): The value provided for `h5_path` during instantiation.
+        no_write (bool): The value provided for `no_write` during instantiation.
+        group (str): The group in the hdf5 file in which results are saved by
+            default. When a `Run` instance is created from within a lyse
+            singleshot or multishot routine, `group` will be set to the name of
+            the running routine. If created from outside a lyse script it will
+            be set to `None`. To change the default group for saving results,
+            use the `set_group()` method. Note that if `self.group` is `None`
+            and no value is provided for the optional `group` argument used by
+            the `save...()` methods, a `ValueError` will be raised.
+    """
     def __init__(self,h5_path,no_write=False):
         self.no_write = no_write
         self.group = None

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -153,16 +153,16 @@ class Run(object):
     def group(self):
         """str: The group in the hdf5 file in which results are saved by default.
         
-            When a `Run` instance is created from within a lyse singleshot or
-            multishot routine, `group` will be set to the name of the running
-            routine. If created from outside a lyse script it will be set to
-            `None`. To change the default group for saving results, use the
-            `set_group()` method. Note that if `self.group` is `None` and no
-            value is provided for the optional `group` argument used by the
-            `save...()` methods, a `ValueError` will be raised.
-            
-            Attempting to directly set `self.group`'s value will automatically
-            call `self.set_group()`.
+        When a `Run` instance is created from within a lyse singleshot or
+        multishot routine, `group` will be set to the name of the running
+        routine. If created from outside a lyse script it will be set to `None`.
+        To change the default group for saving results, use the `set_group()`
+        method. Note that if `self.group` is `None` and no value is provided for
+        the optional `group` argument used by the `save...()` methods, a
+        `ValueError` will be raised.
+        
+        Attempting to directly set `self.group`'s value will automatically call
+        `self.set_group()`.
         """
         return self._group
 

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -257,8 +257,9 @@ class Run(object):
                 result will be saved as an attribute. If set to `None`, then the
                 result will be saved to `self.group` in `'/results'`. Note that
                 if a value is passed for `group` here then it will NOT have
-                `'/result'` prepended to it. This is in contrast to using the
-                default group set with `self.set_group()`; when the default
+                `'/result'` prepended to it which allows the caller to save
+                results anywhere in the hdf5 file. This is in contrast to using
+                the default group set with `self.set_group()`; when the default
                 group is set with that method it WILL have `'/results'`
                 prepended to it when before saving results. Defaults to `None`.
             overwrite (bool, optional): Sets whether or not to overwrite the

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -145,6 +145,18 @@ class Run(object):
                 h5_file[location].create_group(groupname)
 
     def set_group(self, groupname):
+        """Set the default hdf5 file group for saving results.
+
+        The `save...()` methods will save their results to `self.group` if an
+        explicit value for their optional `group` argument is not given. This
+        method updates `self.group`, making sure to create the group in the hdf5
+        file if it does not already exist.
+
+        Args:
+            groupname (str): The name of the hdf5 file group in which to save
+                results by default. The group will be created in the
+                `'/results'` group of the hdf5 file.
+        """
         self._create_group_if_not_exists(self.h5_path, '/results', groupname)
         self.group = groupname
 

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -102,18 +102,18 @@ def globals_diff(run1, run2, group=None):
     return dict_diff(run1.get_globals(group), run2.get_globals(group))
  
 class Run(object):
-    """A class for saving/retrieving data to/from a run's hdf5 file.
+    """A class for saving/retrieving data to/from a shot's hdf5 file.
 
     This class implements methods that allow the user to retrieve data from a
-    run's hdf5 file such as images, traces, and the values of globals. It also
+    shot's hdf5 file such as images, traces, and the values of globals. It also
     provides methods for saving and retrieving results from analysis.
 
     Args:
         h5_path (str): The path, including file name and extension, to the hdf5
-            file for a run.
-        no_write (bool, optional): Set to `True` to prevent editing the run
-            file. Note that doing so prohibits the ability to save results to
-            the file. Defaults to `False`.
+            file for a shot.
+        no_write (bool, optional): Set to `True` to prevent editing the shot's
+            hdf5 file. Note that doing so prohibits the ability to save results
+            to the file. Defaults to `False`.
     """
     def __init__(self,h5_path,no_write=False):
         self.__h5_path = h5_path

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -329,9 +329,43 @@ class Run(object):
 
     def save_result_array(self, name, data, group=None, 
                           overwrite=True, keep_attrs=False, **kwargs):
-        """Save data array to h5 file. Defaults are to save to the active 
-        group in the 'results' group and overwrite existing data.
-        Additional keyword arguments are passed directly to h5py.create_dataset()."""
+        """Save an array of data to the hdf5 h5 file.
+
+        With the default argument values this method saves to `self.group` in
+        the `'/results'` group and overwrites any existing value without keeping
+        the dataset's previous attributes. Additional keyword arguments are
+        passed directly to `h5py.create_dataset()`.
+
+        Args:
+            name (str): The name of the result. This will be the name of the
+                dataset added to the hdf5 file.
+            data (:obj:`numpy:numpy.array`): The data to save to the hdf5 file.
+            group (str, optional): The group in the hdf5 file in which the
+                result will be saved as a dataset. If set to `None`, then the
+                result will be saved in `self.group` in `'/results'`. Note that
+                if a value is passed for `group` here then it will NOT have
+                `'/result'` prepended to it which allows the caller to save
+                results anywhere in the hdf5 file. This is in contrast to using
+                the default group set with `self.set_group()`; when the default
+                group is set with that method it WILL have `'/results'`
+                prepended to it when saving results. Defaults to `None`..
+            overwrite (bool, optional): Sets whether or not to overwrite the
+                previous value if the dataset already exists. If set to
+                `False` and the dataset already exists, a `PermissionError` is
+                raised. Defaults to `True`.
+            keep_attrs (bool, optional): Whether or not to keep the dataset's
+                attributes when overwriting it, i.e. if the dataset already
+                existed. Defaults to `False`.
+
+        Raises:
+            PermissionError: A `PermissionError` is raised if `self.no_write` is
+                `True` because saving the result would edit the file.
+            ValueError: A `ValueError` is raised if `self.group` is `None` and
+                no value is provided for `group` because the method then doesn't
+                know where to save the result.
+            PermissionError: A `PermissionError` is raised if a dataset with
+                name `name` already exists but `overwrite` is set to `False`.
+        """
         if self.no_write:
             msg = "Cannot save result; this instance is read-only."
             raise PermissionError(msg)

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -167,7 +167,12 @@ class Run(object):
                 msg = "Cannot create group; this run is read-only."
                 raise PermissionError(msg)
             with h5py.File(h5_path, 'r+') as h5_file:
-                h5_file[location].create_group(groupname)
+                # Catch the ValueError raised if the group was created by
+                # something else between the check above and now. 
+                try:
+                    h5_file[location].create_group(groupname)
+                except ValueError:
+                    pass
 
     def set_group(self, groupname):
         """Set the default hdf5 file group for saving results.

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -333,11 +333,8 @@ class Run(object):
         group in the 'results' group and overwrite existing data.
         Additional keyword arguments are passed directly to h5py.create_dataset()."""
         if self.no_write:
-            raise Exception('This run is read-only. '
-                            'You can\'t save results to runs through a '
-                            'Sequence object. Per-run analysis should be done '
-                            'in single-shot analysis routines, in which a '
-                            'single Run object is used')
+            msg = "Cannot save result; this instance is read-only."
+            raise PermissionError(msg)
         with h5py.File(self.h5_path, 'a') as h5_file:
             attrs = {}
             if not group:
@@ -359,8 +356,14 @@ class Run(object):
                         attrs = dict(h5_file[group][name].attrs)
                     del h5_file[group][name]
                 else:
-                    raise Exception('Dataset %s exists. Use overwrite=True to overwrite.' % 
-                                     group + '/' + name)
+                    msg = """Cannot save result; group '{group}' already has
+                        dataset '{name}' and overwrite is set to False. Set
+                        overwrite=True to overwrite the existing
+                        value.""".format(
+                            group=group,
+                            name=name,
+                        )
+                    raise PermissionError(dedent(msg))
             h5_file[group].create_dataset(name, data=data, **kwargs)
             for key, val in attrs.items():
                 h5_file[group][name].attrs[key] = val

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -385,7 +385,6 @@ class Run(object):
         names = args[::2]
         values = args[1::2]
         for name, value in zip(names, values):
-            print('saving %s =' % name, value)
             self.save_result(name, value, **kwargs)
             
     def save_results_dict(self, results_dict, uncertainties=False, **kwargs):

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -149,7 +149,7 @@ class Run(object):
             # 'Run.set_group(groupname), specifying the name of the group '
             # 'you would like to save results to. This normally comes from '
             # 'the filename of your script, but since you\'re in interactive '
-            # 'mode, there is no scipt name.\n')
+            # 'mode, there is no script name.\n')
             pass
 
     def _create_group_if_not_exists(self, h5_path, location, groupname):
@@ -202,16 +202,16 @@ class Run(object):
     def get_trace(self,name):
         with h5py.File(self.h5_path, 'r') as h5_file:
             if not name in h5_file['data']['traces']:
-                raise Exception('The trace \'%s\' doesn not exist'%name)
+                raise Exception('The trace \'%s\' does not exist'%name)
             trace = h5_file['data']['traces'][name]
             return array(trace['t'],dtype=float),array(trace['values'],dtype=float)         
 
     def get_result_array(self,group,name):
         with h5py.File(self.h5_path, 'r') as h5_file:
             if not group in h5_file['results']:
-                raise Exception('The result group \'%s\' doesn not exist'%group)
+                raise Exception('The result group \'%s\' does not exist'%group)
             if not name in h5_file['results'][group]:
-                raise Exception('The result array \'%s\' doesn not exist'%name)
+                raise Exception('The result array \'%s\' does not exist'%name)
             return array(h5_file['results'][group][name])
             
     def get_result(self, group, name):
@@ -321,7 +321,7 @@ class Run(object):
     def save_results(self, *args, **kwargs):
         """Iteratively call save_result() on multiple results.
         Assumes arguments are ordered such that each result to be saved is
-        preceeded by the name of the attribute to save it under.
+        preceded by the name of the attribute to save it under.
         Keywords arguments are passed to each call of save_result()."""
         names = args[::2]
         values = args[1::2]
@@ -340,7 +340,7 @@ class Run(object):
     def save_result_arrays(self, *args, **kwargs):
         """Iteratively call save_result_array() on multiple data sets. 
         Assumes arguments are ordered such that each dataset to be saved is 
-        preceeded by the name to save it as. 
+        preceded by the name to save it as. 
         All keyword arguments are passed to each call of save_result_array()."""
         names = args[::2]
         values = args[1::2]
@@ -485,7 +485,7 @@ class Sequence(Run):
             'Sequence.set_group(groupname), specifying the name of the group '
             'you would like to save results to. This normally comes from '
             'the filename of your script, but since you\'re in interactive '
-            'mode, there is no scipt name. Opening in read only mode for '
+            'mode, there is no script name. Opening in read only mode for '
             'the moment.\n')
             self.no_write = True
         

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -124,9 +124,9 @@ class Run(object):
                      
         try:
             if not self.no_write:
-                # The group were this run's results will be stored in the h5 file
-                # will be the name of the python script which is instantiating
-                # this Run object:
+                # The group where this run's results will be stored in the h5
+                # file will be the name of the python script which is
+                # instantiating this Run object:
                 frame = inspect.currentframe()
                 __file__ = frame.f_back.f_globals['__file__']
                 group = os.path.basename(__file__).split('.py')[0]


### PR DESCRIPTION
This PR attempts to resolve #78 

Changes:
* Prevent `Run.set_group()` from creating the group in the hdf5 file if `self.no_write` is `True`.
* Make `Run._create_group_if_not_exists()` raise an error if the group doesn't already exist but `self.no_write` is `True`.
* `Run._create_group_if_not_exists()` now catches the `ValueError` raised if something else creates the group between when  `Run._create_group_if_not_exists()` sees that the group doesn't exist and when it actually tries to create the group.
* Ditch the usage of `self._no_group` to backup/restore `self.no_write`.
  * Instead set `self.group` to `None` by default if there's no lyse script running to name it after, then set the save methods to raise an exception if they need `self.group` but it is `None`.
* Removed the `print()` statement from `Run.save_results()`.
* Make `Run`'s `h5_path`, `no_write`, and `group` attributes private properties.
* Make error messages in `Run.save_result()` and `Run.save_result_array()` more accurate.
* Resolve the bug where `Sequence.__init__()` would fail if the hdf5 file didn't already exist, first brought up in PR #73 .
* Refactor `Sequence.__init__()` to use `Run.__init__()`.
* Add some docstrings in `__init__.py`.
* Fix a few typos in other parts of the code.