### PR TITLE
Use to_parquet instead of depricated msgpack

### DIFF
--- a/lyse/__main__.py
+++ b/lyse/__main__.py
@@ -2243,23 +2243,23 @@ class Lyse(object):
             for sequence in sequences:
                 sequence_df = pandas.DataFrame(df[df['sequence'] == sequence], columns=df.columns).dropna(axis=1, how='all')
                 labscript = sequence_df['labscript'].iloc[0]
-                filename = "dataframe_{}_{}.msg".format(sequence.to_pydatetime().strftime("%Y%m%dT%H%M%S"),labscript[:-3])
+                filename = "dataframe_{}_{}.ftr".format(sequence.to_pydatetime().strftime("%Y%m%dT%H%M%S"),labscript[:-3])
                 if not choose_folder:
                     save_path = os.path.dirname(sequence_df['filepath'].iloc[0])
                 sequence_df.infer_objects()
                 for col in sequence_df.columns :
                     if sequence_df[col].dtype == object:
                         sequence_df[col] = pandas.to_numeric(sequence_df[col], errors='ignore')
-                sequence_df.to_msgpack(os.path.join(save_path, filename))
+                sequence_df.to_parquet(os.path.join(save_path, filename))
         else:
             error_dialog('Dataframe is empty')
 
     def on_load_dataframe_triggered(self):
-        default = os.path.join(self.exp_config.get('paths', 'experiment_shot_storage'), 'dataframe.msg')
+        default = os.path.join(self.exp_config.get('paths', 'experiment_shot_storage'), 'dataframe.ftr')
         file = QtWidgets.QFileDialog.getOpenFileName(self.ui,
                         'Select dataframe file to load',
                         default,
-                        "dataframe files (*.msg)")
+                        "dataframe files (*.ftr)")
         if type(file) is tuple:
             file, _ = file
         if not file:
@@ -2268,8 +2268,8 @@ class Lyse(object):
         # Convert to standard platform specific path, otherwise Qt likes
         # forward slashes:
         file = os.path.abspath(file)
-        df = pandas.read_msgpack(file).sort_values("run time").reset_index()
-                
+        df = pandas.read_parquet(file).sort_values("run time").reset_index()
+
         # Check for changes in the shot files since the dataframe was exported
         def changed_since(filepath, time):
             if os.path.isfile(filepath):

--- a/lyse/__main__.py
+++ b/lyse/__main__.py
@@ -1602,7 +1602,7 @@ class DataFrameModel(QtCore.QObject):
         # Update the Qt model:
         for filepath in to_add:
             self.update_row(filepath, dataframe_already_updated=True)
-            
+        app.filebox.set_add_shots_progress(None, None, None)
 
     @inmain_decorator()
     def get_first_incomplete(self):

--- a/lyse/__main__.py
+++ b/lyse/__main__.py
@@ -2243,7 +2243,7 @@ class Lyse(object):
             for sequence in sequences:
                 sequence_df = pandas.DataFrame(df[df['sequence'] == sequence], columns=df.columns).dropna(axis=1, how='all')
                 labscript = sequence_df['labscript'].iloc[0]
-                filename = "dataframe_{}_{}.ftr".format(sequence.to_pydatetime().strftime("%Y%m%dT%H%M%S"),labscript[:-3])
+                filename = "dataframe_{}_{}.parquet".format(sequence.to_pydatetime().strftime("%Y%m%dT%H%M%S"),labscript[:-3])
                 if not choose_folder:
                     save_path = os.path.dirname(sequence_df['filepath'].iloc[0])
                 sequence_df.infer_objects()
@@ -2255,11 +2255,11 @@ class Lyse(object):
             error_dialog('Dataframe is empty')
 
     def on_load_dataframe_triggered(self):
-        default = os.path.join(self.exp_config.get('paths', 'experiment_shot_storage'), 'dataframe.ftr')
+        default = os.path.join(self.exp_config.get('paths', 'experiment_shot_storage'), 'dataframe.parquet')
         file = QtWidgets.QFileDialog.getOpenFileName(self.ui,
                         'Select dataframe file to load',
                         default,
-                        "dataframe files (*.ftr)")
+                        "dataframe files (*.parquet)")
         if type(file) is tuple:
             file, _ = file
         if not file:

--- a/lyse/__main__.py
+++ b/lyse/__main__.py
@@ -2279,9 +2279,8 @@ class Lyse(object):
 
         filepaths = df["filepath"].tolist()
         changetime_cache = os.path.getmtime(file)
-        need_updating = np.where(map(lambda x: changed_since(x, changetime_cache), filepaths))[0]
+        need_updating = np.where(list(map(lambda x: changed_since(x, changetime_cache), filepaths)))[0]
         need_updating = np.sort(need_updating)[::-1]  # sort in descending order to not remove the wrong items with pop
-
         # Reload the files where changes where made since exporting
         for index in need_updating:
             filepath = filepaths.pop(index)


### PR DESCRIPTION
This solves issue 82 (https://github.com/labscript-suite/lyse/issues/82) by offering a new possibility to save Dataframes. I am still unsure how to ensure pandas<1.2.
Furthermore I solve two bugs that came up:
1. The first shot in the saved dataframe was always reloaded, even if it had not changed.
2. The progress bar was stuck after loading a dataframe where no files had changed. Maybe the bugfix I used is not the best ... I am open for better ideas.