### PR TITLE
Implement optimization described in #92

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -67,7 +67,7 @@ Single shot analysis with global file opening
 	with Run(path).open('r+') as shot:
 
 		# Obtaining a trace:
-		t, mot_fluorecence = run.get_trace('mot fluorecence')
+		t, mot_fluorecence = shot.get_trace('mot fluorecence')
 
 		# Now we might do some analysis on this data. Say we've written a
 		# linear fit function (or we're calling some other libaries linear

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -53,6 +53,38 @@ An analysis on a single shot
 	# shots in a multishot analysis:
 	run.save_result('mot loadrate', c)
 
+Single shot analysis with global file opening
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+	from lyse import *
+
+	# Instantiate Run object and open
+	# Globally opening the shot keeps the h5 file open
+	# This prevents excessive opening and closing of the file
+	# which can slow down the analysis
+	with Run(path).open('r+') as shot:
+
+		# Obtaining a trace:
+		t, mot_fluorecence = run.get_trace('mot fluorecence')
+
+		# Now we might do some analysis on this data. Say we've written a
+		# linear fit function (or we're calling some other libaries linear
+		# fit function):
+		m, c = linear_fit(t, mot_fluorecence)
+		int_tot = mot_fluorecence.sum()
+		mf_min = mot_fluorecence.min()
+		mf_max = mot_fluorecence.max()
+
+		normalised_fluorecence = normalise_response(mot_fluorecence)
+
+		# We might wish to save this result so that we can compare it across
+		# shots in a multishot analysis:
+		shot.save_result('mot loadrate', c)
+		shot.save_result('mot integrated', int_tot)
+		shot.save_results('mot fl min', mf_min, 'mot fl max', mf_max)
+		shot.save_result_array('norm mot fluorecence', normalised_fluorecence)
 
 An analysis on multiple shots
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -317,6 +317,9 @@ class Run(object):
                 Must be 'r', 'a', 'r+', 'w', 'w-', or 'x'.
                 Lyse typically only uses 'r' and 'r+'.
 
+        Yields:
+            :class:`h5py:h5py.File`: Handle to the opened h5 file.
+
         Examples:
             >>> from lyse import *
             >>> shot = Run(path)

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -336,13 +336,16 @@ class Run(object):
 
         # ensure no_write is respected
         if self.no_write and mode != 'r':
-            msg = f'Cannot open file with a write mode; this run is read-only'
+            msg = 'Cannot open file with a write mode; this run is read-only'
             raise PermissionError(msg)
             
-        # ensure file is not already opened
+        # check if file is already open, do nothing if modes compatible
         if self.__h5_file is not None:
-            msg = 'h5_file already opened'
-            raise PermissionError(msg)
+            # ensure no-write is respected
+            if (self.__h5_file.mode == 'r') and (mode != 'r'):
+                msg = 'Cannot open file with a write mode; this run is read-only'
+                raise PermissionError(msg)
+            return None
         
         with h5py.File(self.h5_path, mode) as f:
             self.__h5_file = f

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -335,12 +335,9 @@ class Run(object):
         """
 
         # ensure no_write is respected
-        if self.no_write:
-            if mode == 'r':
-                pass
-            else:
-                msg = f'Cannot open file with a write mode; this run is read-only'
-                raise PermissionError(msg)
+        if self.no_write and mode != 'r':
+            msg = f'Cannot open file with a write mode; this run is read-only'
+            raise PermissionError(msg)
             
         # ensure file is not already opened
         if self.__h5_file is not None:
@@ -374,12 +371,9 @@ class Run(object):
             @functools.wraps(func)
             def wrapper(self, *args, **kwargs):
 
-                if self.no_write:
-                    if mode == 'r':
-                        pass
-                    else:
-                        msg = f'Cannot perform operation {func.__name__:s}; this run is read-only'
-                        raise PermissionError(msg)
+                if self.no_write and mode != 'r':
+                    msg = f'Cannot perform operation {func.__name__:s}; this run is read-only'
+                    raise PermissionError(msg)
 
                 if self.__h5_file is None:
                     with self.open(mode):

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -307,21 +307,20 @@ class Run(object):
     
     @contextlib.contextmanager
     def open(self, mode):
-        """Opens the Run's h5 file for successive reads/writes.
+        """Context manager to open the Run's h5 file for successive reads/writes.
 
-        Intended to be used as a context manager.
         Supports all h5 modes, though only `'r'` and `'r+'`/`'a'` are typically
         used within lyse itself.
 
         Args:
-            mode (str): which mode to open the h5 file with.
+            mode (str): which :class:`h5py:h5py.File` mode to open the h5 file with.
                 Must be 'r', 'a', 'r+', 'w', 'w-', or 'x'.
-                Lyse typically only uses 'r' and 'a'.
+                Lyse typically only uses 'r' and 'r+'.
 
         Examples:
             >>> from lyse import *
             >>> shot = Run(path)
-            >>> with shot.open('a'):
+            >>> with shot.open('r+'):
             >>>     # shot processing that requires reads/writes
             >>>     t, vals = shot.get_trace('my_trace')
             >>>     results = vals**2
@@ -355,17 +354,22 @@ class Run(object):
                 self.__h5_file = None
             
     def open_file(mode):
-        """Wrapper for lyse functions to allow using previously opened file with context manager.
+        """Decorator for lyse functions to allow using previously opened file with context manager.
         
         If multiple read/write operations happen on a Run in a single shot,
         opening the h5file once via the context manager `open`
         can speed up the analysis execution time by limiting the number of times
         the file must be opened/closed.
 
+        Note that an opened :class:`h5py:h5py.File` can only be in modes `'r'` or `'r+'`.
+        All other mode opening options differ in file creation logic only.
+        In particular, all mode opening options except `'r'` are considered
+        `'r+'` once the file is open.
+
         Args:
-            mode (str): which mode to open the h5 file with.
+            mode (str): which :class:`h5py:h5py.File` mode to open the h5 file with.
                 Must be 'r', 'a', 'r+', 'w', 'w-', or 'x'.
-                Lyse typically only uses 'r' and 'a'.
+                Lyse typically only uses 'r' and 'r+'.
 
         Raises:
             PermissionError: If the Run is set as read-only but a write mode is requested

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -344,13 +344,13 @@ class Run(object):
             if (self.__h5_file.mode == 'r') and (mode != 'r'):
                 msg = 'Cannot open file with a write mode; this run is read-only'
                 raise PermissionError(msg)
-            yield None
+            yield self.__h5_file
             return
         
         with h5py.File(self.h5_path, mode) as f:
             self.__h5_file = f
             try:
-                yield None
+                yield self.__h5_file
             finally:
                 self.__h5_file = None
             

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -344,7 +344,8 @@ class Run(object):
             if (self.__h5_file.mode == 'r') and (mode != 'r'):
                 msg = 'Cannot open file with a write mode; this run is read-only'
                 raise PermissionError(msg)
-            return None
+            yield None
+            return
         
         with h5py.File(self.h5_path, mode) as f:
             self.__h5_file = f

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -225,6 +225,53 @@ def globals_diff(run1, run2, group=None):
     """
     return dict_diff(run1.get_globals(group), run2.get_globals(group))
  
+def open_file(mode):
+    """Decorator for lyse functions to allow using previously opened file with context manager.
+    
+    If multiple read/write operations happen on a Run in a single shot,
+    opening the h5file once via the context manager `open`
+    can speed up the analysis execution time by limiting the number of times
+    the file must be opened/closed.
+
+    Note that an opened :class:`h5py:h5py.File` can only be in modes `'r'` or `'r+'`.
+    All other mode opening options differ in file creation logic only.
+    In particular, all mode opening options except `'r'` are considered
+    `'r+'` once the file is open.
+
+    Args:
+        mode (str): which :class:`h5py:h5py.File` mode to open the h5 file with.
+            Must be 'r', 'a', 'r+', 'w', 'w-', or 'x'.
+            Lyse typically only uses 'r' and 'r+'.
+
+    Returns:
+        Decorator for :class:`~.Run` methods that need to read/write the shot file
+
+    Raises:
+        PermissionError: If the Run is set as read-only but a write mode is requested
+    """
+    def decorator_open_file(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+
+            if self.no_write and mode != 'r':
+                msg = f'Cannot perform operation {func.__name__:s}; this run is read-only'
+                raise PermissionError(msg)
+
+            if self.h5_file is None:
+                with self.open(mode):
+                    return func(self, *args, **kwargs)
+            else:
+                if (self.h5_file.mode == 'r') and (mode != 'r'):
+                    msg = (f"Cannot perform operation {func.__name__:s}; "
+                        + f"requested mode {mode:s} not compatible with "
+                        + f"h5_file's mode {self.h5_file.mode:s}")
+                    raise PermissionError(msg)
+                else:
+                    return func(self, *args, **kwargs)
+            
+        return wrapper
+    return decorator_open_file
+
 class Run(object):
     """A class for saving/retrieving data to/from a shot's hdf5 file.
 
@@ -356,50 +403,6 @@ class Run(object):
                 yield self.__h5_file
             finally:
                 self.__h5_file = None
-            
-    def open_file(mode):
-        """Decorator for lyse functions to allow using previously opened file with context manager.
-        
-        If multiple read/write operations happen on a Run in a single shot,
-        opening the h5file once via the context manager `open`
-        can speed up the analysis execution time by limiting the number of times
-        the file must be opened/closed.
-
-        Note that an opened :class:`h5py:h5py.File` can only be in modes `'r'` or `'r+'`.
-        All other mode opening options differ in file creation logic only.
-        In particular, all mode opening options except `'r'` are considered
-        `'r+'` once the file is open.
-
-        Args:
-            mode (str): which :class:`h5py:h5py.File` mode to open the h5 file with.
-                Must be 'r', 'a', 'r+', 'w', 'w-', or 'x'.
-                Lyse typically only uses 'r' and 'r+'.
-
-        Raises:
-            PermissionError: If the Run is set as read-only but a write mode is requested
-        """
-        def decorator_open_file(func):
-            @functools.wraps(func)
-            def wrapper(self, *args, **kwargs):
-
-                if self.no_write and mode != 'r':
-                    msg = f'Cannot perform operation {func.__name__:s}; this run is read-only'
-                    raise PermissionError(msg)
-
-                if self.__h5_file is None:
-                    with self.open(mode):
-                        return func(self, *args, **kwargs)
-                else:
-                    if (self.__h5_file.mode == 'r') and (mode != 'r'):
-                        msg = (f"Cannot perform operation {func.__name__:s}; "
-                            + f"requested mode {mode:s} not compatible with "
-                            + f"h5_file's mode {self.__h5_file.mode:s}")
-                        raise PermissionError(msg)
-                    else:
-                        return func(self, *args, **kwargs)
-                
-            return wrapper
-        return decorator_open_file
 
     @property
     def group(self):

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -347,12 +347,12 @@ class Run(object):
             msg = 'h5_file already opened'
             raise PermissionError(msg)
         
-        self.__h5_file = h5py.File(self.h5_path, mode)
-        try:
-            yield None
-        finally:
-            self.__h5_file.close()
-            self.__h5_file = None
+        with h5py.File(self.h5_path, mode) as f:
+            self.__h5_file = f
+            try:
+                yield None
+            finally:
+                self.__h5_file = None
             
     def open_file(mode):
         """Wrapper for lyse functions to allow using previously opened file with context manager.

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -381,7 +381,7 @@ class Run(object):
             >>> with shot.open('r'):
             >>>     # shot processing that requires reads/writes
             >>>     _, vals = shot.get_trace('my_trace')
-            >>> with shot.open('r+')
+            >>> with shot.open('r+'):
             >>>     results = vals**2
             >>>     shot.save_result_array('my_result', results)
             >>>     _, vals2 = shot.get_trace('my_other_trace')
@@ -396,7 +396,7 @@ class Run(object):
             >>> from lyse import *
             >>> with Run(path).open('r+') as shot:
             >>>     # shot processing that requires reads/writes
-            >>>     t, vals = shots.get_trace('my_trace')
+            >>>     t, vals = shot.get_trace('my_trace')
             >>>     results = vals**2
             >>>     shot.save_result_array('my_result', results)
             >>>     # Shot processing that doesn't require h5 reads/writes

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -426,7 +426,7 @@ class Run(object):
         the file is actually written to."""
         create_group = False
         with h5py.File(h5_path, 'r') as h5_file:
-            if not groupname in h5_file[location]:
+            if groupname not in h5_file[location]:
                 create_group = True
         if create_group:
             if self.no_write:
@@ -484,7 +484,7 @@ class Run(object):
         Returns:
             dict: Dictionary of attributes.
         """
-        if not group in self.h5_file:
+        if group not in self.h5_file:
             raise Exception('The group \'%s\' does not exist'%group)
         return get_attributes(self.h5_file[group])
 
@@ -504,7 +504,7 @@ class Run(object):
             :obj:`numpy:numpy.ndarray`: Returns 2-D timetrace of times `'t'`
             and values `'values'`.
         """
-        if not name in self.h5_file['data']['traces']:
+        if name not in self.h5_file['data']['traces']:
             raise Exception('The trace \'%s\' does not exist'%name)
         trace = self.h5_file['data']['traces'][name]
         
@@ -531,7 +531,7 @@ class Run(object):
         if not 'data' in self.h5_file:
             raise Exception('The shot has no data group')
         name=name.encode()
-        if not name in self.h5_file['data']['waits']['label']:
+        if name not in self.h5_file['data']['waits']['label']:
             raise Exception('The wait \'%s\' does not exist'%name.decode())
         name_index, =where(self.h5_file['data']['waits']['label']==name)[0]
         return self.h5_file['data']['waits'][name_index]
@@ -546,9 +546,9 @@ class Run(object):
         Returns:
             :obj:`numpy:numpy.ndarray`: Returns 2D structured numpy array of the waits and their parameters.
         """
-        if not 'data' in self.h5_file:
+        if 'data' not in self.h5_file:
             raise Exception('The shot has no data group')
-        if not 'waits' in self.h5_file['data']:
+        if 'waits' not in self.h5_file['data']:
             raise Exception('The shot has no waits')
         return self.h5_file['data']['waits'][()]
 
@@ -567,9 +567,9 @@ class Run(object):
         Returns:
             :obj:`numpy:numpy.ndarray`: Numpy array of the saved data.
         """
-        if not group in self.h5_file['results']:
+        if group not in self.h5_file['results']:
             raise Exception('The result group \'%s\' does not exist'%group)
-        if not name in self.h5_file['results'][group]:
+        if name not in self.h5_file['results'][group]:
             raise Exception('The result array \'%s\' does not exist'%name)
         return array(self.h5_file['results'][group][name])
 
@@ -589,9 +589,9 @@ class Run(object):
             : Result with appropriate type, as determined by 
             :obj:`labscript-utils:labscript_utils.properties.get_attribute`.
         """
-        if not group in self.h5_file['results']:
+        if group not in self.h5_file['results']:
             raise Exception('The result group \'%s\' does not exist'%group)
-        if not name in self.h5_file['results'][group].attrs.keys():
+        if name not in self.h5_file['results'][group].attrs.keys():
             raise Exception('The result \'%s\' does not exist'%name)
         return get_attribute(self.h5_file['results'][group], name)
 
@@ -664,7 +664,7 @@ class Run(object):
                 raise ValueError(dedent(msg))
             # Save to analysis results group by default
             group = 'results/' + self.group
-        elif not group in self.h5_file:
+        elif group not in self.h5_file:
             # Create the group if it doesn't exist
             self.h5_file.create_group(group) 
         if name in self.h5_file[group].attrs and not overwrite:
@@ -735,7 +735,7 @@ class Run(object):
                 raise ValueError(dedent(msg))
             # Save dataset to results group by default
             group = 'results/' + self.group
-        elif not group in self.h5_file:
+        elif group not in self.h5_file:
             # Create the group if it doesn't exist
             self.h5_file.create_group(group) 
         if name in self.h5_file[group]:
@@ -884,13 +884,13 @@ class Run(object):
         Returns:
             :obj:`numpy:numpy.ndarray`: 2-D image array.
         """
-        if not 'images' in self.h5_file:
+        if 'images' not in self.h5_file:
             raise Exception('File does not contain any images')
-        if not orientation in self.h5_file['images']:
+        if orientation not in self.h5_file['images']:
             raise Exception('File does not contain any images with orientation \'%s\''%orientation)
-        if not label in self.h5_file['images'][orientation]:
+        if label not in self.h5_file['images'][orientation]:
             raise Exception('File does not contain any images with label \'%s\''%label)
-        if not image in self.h5_file['images'][orientation][label]:
+        if image not in self.h5_file['images'][orientation][label]:
             raise Exception('Image \'%s\' not found in file'%image)
         return array(self.h5_file['images'][orientation][label][image])
 
@@ -957,9 +957,9 @@ class Run(object):
         Returns:
             dict: Dictionary of attributes and their values.
         """
-        if not 'images' in self.h5_file:
+        if 'images' not in self.h5_file:
             raise Exception('File does not contain any images')
-        if not orientation in self.h5_file['images']:
+        if orientation not in self.h5_file['images']:
             raise Exception('File does not contain any images with orientation \'%s\''%orientation)
         return get_attributes(self.h5_file['images'][orientation])
 
@@ -1225,7 +1225,7 @@ def figure_to_clipboard(figure=None, **kwargs):
     from zprocess import start_daemon
     import tempfile
 
-    if not 'bbox_inches' in kwargs:
+    if 'bbox_inches' not in kwargs:
         kwargs['bbox_inches'] = 'tight'
                
     if figure is None:

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -225,50 +225,6 @@ def globals_diff(run1, run2, group=None):
     """
     return dict_diff(run1.get_globals(group), run2.get_globals(group))
  
-def open_file(mode):
-    """Decorator for lyse functions to allow using previously opened file with context manager.
-    
-    If multiple read/write operations happen on a Run in a single shot,
-    opening the h5file once via the context manager `open`
-    can speed up the analysis execution time by limiting the number of times
-    the file must be opened/closed.
-
-    Note that an opened :class:`h5py:h5py.File` can only be in modes `'r'` or `'r+'`.
-    All other mode opening options differ in file creation logic only.
-    In particular, all mode opening options except `'r'` are considered
-    `'r+'` once the file is open.
-
-    Args:
-        mode (str): which :class:`h5py:h5py.File` mode to open the h5 file with.
-            Must be 'r', 'a', 'r+', 'w', 'w-', or 'x'.
-            Lyse typically only uses 'r' and 'r+'.
-
-    Raises:
-        PermissionError: If the Run is set as read-only but a write mode is requested
-    """
-    def decorator_open_file(func):
-        @functools.wraps(func)
-        def wrapper(self, *args, **kwargs):
-
-            if self.no_write and mode != 'r':
-                msg = f'Cannot perform operation {func.__name__:s}; this run is read-only'
-                raise PermissionError(msg)
-
-            if self.__h5_file is None:
-                with self.open(mode):
-                    return func(self, *args, **kwargs)
-            else:
-                if (self.__h5_file.mode == 'r') and (mode != 'r'):
-                    msg = (f"Cannot perform operation {func.__name__:s}; "
-                        + f"requested mode {mode:s} not compatible with "
-                        + f"h5_file's mode {self.__h5_file.mode:s}")
-                    raise PermissionError(msg)
-                else:
-                    return func(self, *args, **kwargs)
-            
-        return wrapper
-    return decorator_open_file
-
 class Run(object):
     """A class for saving/retrieving data to/from a shot's hdf5 file.
 
@@ -396,6 +352,50 @@ class Run(object):
                 yield None
             finally:
                 self.__h5_file = None
+            
+    def open_file(mode):
+        """Decorator for lyse functions to allow using previously opened file with context manager.
+        
+        If multiple read/write operations happen on a Run in a single shot,
+        opening the h5file once via the context manager `open`
+        can speed up the analysis execution time by limiting the number of times
+        the file must be opened/closed.
+
+        Note that an opened :class:`h5py:h5py.File` can only be in modes `'r'` or `'r+'`.
+        All other mode opening options differ in file creation logic only.
+        In particular, all mode opening options except `'r'` are considered
+        `'r+'` once the file is open.
+
+        Args:
+            mode (str): which :class:`h5py:h5py.File` mode to open the h5 file with.
+                Must be 'r', 'a', 'r+', 'w', 'w-', or 'x'.
+                Lyse typically only uses 'r' and 'r+'.
+
+        Raises:
+            PermissionError: If the Run is set as read-only but a write mode is requested
+        """
+        def decorator_open_file(func):
+            @functools.wraps(func)
+            def wrapper(self, *args, **kwargs):
+
+                if self.no_write and mode != 'r':
+                    msg = f'Cannot perform operation {func.__name__:s}; this run is read-only'
+                    raise PermissionError(msg)
+
+                if self.__h5_file is None:
+                    with self.open(mode):
+                        return func(self, *args, **kwargs)
+                else:
+                    if (self.__h5_file.mode == 'r') and (mode != 'r'):
+                        msg = (f"Cannot perform operation {func.__name__:s}; "
+                            + f"requested mode {mode:s} not compatible with "
+                            + f"h5_file's mode {self.__h5_file.mode:s}")
+                        raise PermissionError(msg)
+                    else:
+                        return func(self, *args, **kwargs)
+                
+            return wrapper
+        return decorator_open_file
 
     @property
     def group(self):


### PR DESCRIPTION
Implements a wrapper function that allows all lyse functions to optionally take a handle to the h5_file instead of opening and closing for each operation. This allows a single open and close operation for a single shot run.

This tends to speed up writes more than reads.

This closes #92