### PR TITLE
Require older tzlocal version due to breaking change in v3.0 onwards

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
   qtutils>=2.2.2
   runmanager>=3.0.0
   scipy
-  tzlocal
+  tzlocal<3.0
   zprocess>=2.2.2
 
 [options.entry_points]


### PR DESCRIPTION
When installing lyse in a fresh Python environment, pip automatically installs the latest version of `tzlocal` (5.0.1 at the moment). The call to `tzlocal` in `dataframe_utilities.py` is using the old API for the package, which was deprecated in v3.0. This PR resolves the issue by setting a restriction on the `tzlocal` version in `setup.cfg`. Alternatively the code could be updated to use the newer `tzlocal` API (and a minimum version added to `setup.cfg`).