### PR TITLE
Break dependency on runmanager by using `labscript_utils.shot_utils.get_shot_globals`

### DIFF
--- a/lyse/dataframe_utilities.py
+++ b/lyse/dataframe_utilities.py
@@ -16,7 +16,7 @@ import tzlocal
 import labscript_utils.shared_drive
 from labscript_utils.connections import _ensure_str
 from labscript_utils.properties import get_attributes
-import runmanager
+from labscript_utils.shot_utils import get_shot_globals
 
 
 def asdatetime(timestr):
@@ -26,7 +26,7 @@ def asdatetime(timestr):
     return pandas.Timestamp(timestr, tz=tz)
 
 def get_nested_dict_from_shot(filepath):
-    row = runmanager.get_shot_globals(filepath)
+    row = get_shot_globals(filepath)
     with h5py.File(filepath,'r') as h5_file:
         if 'results' in h5_file:
             for groupname in h5_file['results']:

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -23,5 +23,4 @@ python:
         path: .
         extra_requirements:
             - docs
-   system_packages: true
    

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,11 @@ install_requires =
   desktop-app>=0.1.2
   h5py
   importlib_metadata
-  labscript_utils>=3.0.0
+  labscript_utils>=3.3.0
   matplotlib
   numpy
   pandas>=0.21
   qtutils>=2.2.2
-  runmanager>=3.0.0
   scipy
   tzlocal
   zprocess>=2.2.2


### PR DESCRIPTION
Partially fixes labscript-suite/runmanager#98