### PR TITLE
Mac os icon

### DIFF
--- a/lyse/analysis_subprocess.py
+++ b/lyse/analysis_subprocess.py
@@ -15,6 +15,7 @@
  
 import labscript_utils.excepthook # I do magic stuff, so import must be in place
 import labscript_utils.h5_lock, h5py
+import labscript_utils.splash
 
 from labscript_utils.ls_zprocess import ProcessTree
 
@@ -509,6 +510,12 @@ if __name__ == '__main__':
     qapplication = QtWidgets.QApplication.instance()
     if qapplication is None:
         qapplication = QtWidgets.QApplication(sys.argv)
+    qapplication.setProperty(
+        '_labscript_icon_path', os.path.join(lyse.utils.LYSE_DIR, 'lyse.svg')
+    )
+    qapplication.setApplicationName('lyse')
+    qapplication.setApplicationDisplayName('lyse')
+    labscript_utils.splash.configure_qapplication(qapplication)
     worker = AnalysisWorker(filepath, to_parent, from_parent)
     qapplication.exec_()
         


### PR DESCRIPTION
This fixes two MacOS specific issues.  First using the QT "MacOS native-style" widgets did not preserve the layout present in windows or linux, so we ask for the "fusion" widgets.  The runmanager tabs specifically did not get the desired stacking behavior to the left of the tabs (and many other things looked bad).

Second the mac desktop apps did not get icons in the dock (they were just generic place holders).

This patches labscript_utils.splash with macos specific updates to fix these problems.  

There is a labscript-utils partner to this pull request.

Lyse required special intervention to assign icons to the worker windows.